### PR TITLE
Update to most recent version of apt package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3 (2018-08-17)
+
+- Support for new apt package.
+
 ## 0.1.2 (2018-03-16)
 
 - Windows support

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "google-glogging",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Google",
   "summary": "A Puppet module to manage Google Stackdriver Logging Agent",
   "license": "Apache-2.0",
@@ -25,8 +25,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+	"9"
       ]
     },
     {
@@ -35,7 +35,8 @@
         "12.04",
         "14.04",
         "16.04",
-        "16.10"
+        "16.10",
+	"18.04"
       ]
     },
     {
@@ -65,7 +66,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 4.1.0 < 5.0.0"
+      "version_requirement": ">= 6.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
No breaking changes in the changelog of the apt package, no reason not to be on the most recent version.